### PR TITLE
Using git+https instead of git

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "optimist": "~0.3.4",
-    "uglify-js": "git://github.com/psq/UglifyJS.git#master"
+    "uglify-js": "git+https://github.com/psq/UglifyJS.git#master"
   },
   "devDependencies": {
     "mocha": "1.0.x",


### PR DESCRIPTION
It is only a tiny things, but I just ran into a case where a client could not access port 9143 (git). It seems to me like the odds of having access to 443 over 9143 are higher, so I would suggest we change the uglify-js dependency (which is on github) to use HTTPS over pure git.
