### PR TITLE
Added additional handling to generateForDir() to support serial/parallel execution

### DIFF
--- a/jsdox.js
+++ b/jsdox.js
@@ -836,6 +836,7 @@ function generateMD(data) {
 
 function generateForDir(filename, destination, cb) {
   var waiting = 0;
+  var touched = 0;
   var error = null;
 
   function oneFile(directory, file, cb) {
@@ -895,11 +896,12 @@ function generateForDir(filename, destination, cb) {
           }
           files.forEach(function(file) {
             if (file.match(/\.js$/)) {
-              oneFile(filename, file, cb);
+              oneFile(filename, file, cb), touched++;
             }
           });
+          if(!touched) cb();
         });
-      }
+      } else cb();
     });
   }
 }


### PR DESCRIPTION
generateForDir() didn't fire the callback in cases when no files were processed, or the directory could not be read.  an example of how jsdox may be used for generating docs for a list of folders in serial can be found here:

https://gist.github.com/mmacmillan/8611517

it shows how directories that don't exist, or directories that have no .js files will not fire the callback, making it difficult to determine if the process has finished.
