### PR TITLE
Adds support for @deprecated

### DIFF
--- a/docs/tags.txt
+++ b/docs/tags.txt
@@ -6,7 +6,7 @@
 # @constructs
 @copyright <some copyright text>
 @default [<some value>]
-@deprecated
+@deprecated [<some description text>]
 @description <some description text>
   || @desc
 @enum [<type>]

--- a/fixtures/test.js
+++ b/fixtures/test.js
@@ -84,4 +84,11 @@ var multi = {
   
 };
 
+/**
+  This is a deprecated function.
+  @deprecated Because I said so
+*/
+function testDeprecated() {
+}
+
 testNamed('test.js');

--- a/jsdox.js
+++ b/jsdox.js
@@ -56,7 +56,7 @@ var TAGS = {
   "const": parseTypeName,
   "copyright": parseText,
   "default": parseValue,
-  "deprecated": parseNothing,
+  "deprecated": parseText,
   "description": parseText,
   "desc": parseText,
   "enum": parseType,
@@ -560,6 +560,13 @@ function analyze(raw) {
           result.overview = tag.value;
           result.description = comment.text;
           break;
+        case 'deprecated':
+          if (current_function) {
+            current_function.deprecated = tag.value ? tag.value : true;
+          } else if (current_method) {
+            current_method.deprecated = tag.value ? tag.value : true;
+          }
+          break;
         case 'param':
           if (current_function) {
             current_function.params.push(tag);
@@ -726,6 +733,13 @@ function generateFunctionsForModule(module, displayName) {
       out += generateH2(proto);
       if (fn.description) {
         out += generateText(fn.description, true);
+      }
+      if (fn.deprecated) {
+        if (typeof fn.deprecated === 'boolean') {
+          out += generateText('**Deprecated**', true);
+        } else {
+          out += generateText('**Deprecated:** ' + fn.deprecated, true);
+        }
       }
       if (fn.params.length) {
         out += generateStrong('Parameters', true);

--- a/sample_output/test.md
+++ b/sample_output/test.md
@@ -71,3 +71,10 @@ test_module.func2(c, d)
 
 **d**,  the second param
 
+test_module.testDeprecated()
+----------------------------
+This is a deprecated function.
+
+
+**Deprecated:** Because I said so
+

--- a/test/file.js
+++ b/test/file.js
@@ -23,7 +23,7 @@ describe('parse file', function() {
 
       var result = jsdox.parseComments(ast);
       console.log('RESULT', util.inspect(result, false, 20, true));
-      result.length.should.equal(7);
+      result.length.should.equal(8);
 
       result[0].tags[0].tag.should.equal('title');
       result[0].tags[1].tag.should.equal('overview');
@@ -42,7 +42,7 @@ describe('parse file', function() {
       if (err) {
         return done(err);
       }
-      result.length.should.equal(7);
+      result.length.should.equal(8);
       // same as test above, shouldn't need to retest for same
       return done();
     });

--- a/test/parser.js
+++ b/test/parser.js
@@ -101,8 +101,8 @@ describe('parseComment', function() {
     });
 
     it('should parse Nothing tag', function() {
-      var result = jsdox.parseLine('** @deprecated  ');
-      result.tag.should.equal('deprecated');
+      var result = jsdox.parseLine('** @private  ');
+      result.tag.should.equal('private');
       should.not.exist(result.value);
       should.not.exist(result.name);
       should.not.exist(result.type);


### PR DESCRIPTION
This PR fixes two issues:
1. `@deprecated` can optionally have text associated with it. It was previously throwing an error if there was any text.
2. There tag does not show in the output.  If `@deprecated` is found, **Deprecated:** [blah] is now in the output.

Tests were updated as well
