### PR TITLE
Markdown generation is handled by Mustache templates

### DIFF
--- a/fixtures/test.js
+++ b/fixtures/test.js
@@ -11,7 +11,20 @@ var util = require('util');
 var fs = require('fs');
 var jsp = require("uglify-js").parser;
 
-
+/**
+ * Collection of stuff
+ * @type {Object}
+ */
+var foo = {
+  /**
+   * I so cool
+   * @return {Boolean|null}
+   * @deprecated Not a good function
+   */
+  bar: function() {
+    return true
+  }
+}
 
 /**
   This is a test function
@@ -21,6 +34,7 @@ var jsp = require("uglify-js").parser;
   @param {Boolean|null} [optional] Changes behavior
   @fires module:foo#one_thing
   @fires module:foo#another
+  @emits module:foo#booyah
 */
 function testNamed(file, optional) {
   fs.readFile(file, function (err, data) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "optimist": "~0.3.4",
     "q": "^1.0.1",
-    "jsdoc3-parser": "^1.0.0"
+    "jsdoc3-parser": "^1.0.0",
+    "mustache": "^0.8.2"
   },
   "devDependencies": {
     "mocha": "1.0.x",

--- a/templates/file.mustache
+++ b/templates/file.mustache
@@ -1,0 +1,22 @@
+{{#modules}}
+{{#name}}
+{{name}}
+---
+{{/name}}
+
+{{#description}}{{{description}}}{{/description}}
+
+{{#functions}}
+{{> function}}
+
+{{/functions}}
+{{/modules}}
+---
+
+{{#copyright}}*{{copyright}}*{{/copyright}}
+
+{{#license}}**License:** {{license}} {{/license}}{{#author}}{{author}}{{/author}}
+
+{{#overview}}**Overview:** {{{overview}}}{{/overview}}
+
+{{#version}}**Version:** {{version}}{{/version}}

--- a/templates/function.mustache
+++ b/templates/function.mustache
@@ -1,0 +1,25 @@
+{{#moduleName}}{{moduleName}}.{{/moduleName}}{{name}}({{#paramsString}}{{paramsString}}{{/paramsString}}) {{#version}}{{version}}{{/version}}
+-----------------------------
+{{#description}}
+{{{description}}}
+
+{{/description}}
+{{#deprecated}}
+Deprecated: {{{deprecated}}}
+
+{{/deprecated}}
+{{#hasParams}}
+**Parameters**
+
+{{/hasParams}}
+{{#params}}
+**{{name}}**: {{#typesString}}{{typesString}}, {{/typesString}}{{#description}}{{{description}}}{{/description}}
+
+{{/params}}
+{{#fires}}
+**Fires**: {{.}}
+
+{{/fires}}
+{{#returns}}
+**Returns**: {{#typesString}}{{typesString}}, {{/typesString}}{{#description}}{{{description}}}{{/description}}
+{{/returns}}


### PR DESCRIPTION
A docblock generator should really just take an AST and pass it off to a templating engine. This PR removes all hardcoded string manipulation to generate markdown. We keep `analyze()` to transform the AST into a more usable form since templates are logicless.

Current output for test.js:
## foo

Can I get some description please
  on more than one line, if possible.
## foo.bar() 

I so cool

Deprecated 

**Returns**: Boolean | null, I so cool
## foo.testNamed(file, optional) 

This is a test function
  with a description on multiple lines

**Parameters**

**file**: String | null, filename to parse
                       this parsing thing is funny business

**optional**: Boolean | null, Changes behavior

**Fires**: module:foo#event:one_thing

**Fires**: module:foo#event:another

**Fires**: module:foo#event:booyah
## foo.testAnonynous() 

function without name

**Returns**: String, the result
## foo.testAnon2() 

second function without name

**Returns**: String, the result
## foo.func1(a, b) 

Can I get some description please
  on more than one line, if possible.

**Parameters**

**a**: the first param

**b**: the second param

**Returns**: the result
## foo.func2(c, d) 

Can I get some description please
  on more than one line, if possible.

**Parameters**

**c**: the first param

**d**: the second param

**Returns**: the other result
## foo.testDeprecated() 

This is a deprecated function.

Deprecated 

---

_(c) 2012 Blah Blah Blah_

**License:** MIT Joe Schmo

**Overview:** What's up?

**Version:** 1.0.1
