### PR TITLE
Contribution guidelines. Fixes #55

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,18 @@
+Contributing guidelines
+---
+
+### Maintainers
+
+* Pascal Belloncle ([@psq](https://twitter.com/psq))
+* Joel Kemp ([@mrjoelkemp](https://twitter.com/mrjoelkemp))
+
+### Disclaimers:
+
+1. If you want to change the stylistic output of the generated markdown, please use the `--templateDir` option to supply custom mustache templates.
+ - Only template changes that incorporate new tags (or fix visual bugs) will be considered for review.
+
+### Pull-requests
+
+If you fixed or added something useful to the project, you can send a pull-request that **includes unit tests** for your change(s).
+Your PR will be reviewed by a maintainer and accepted, or commented for rework, or declined.
+

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 jsdox is a simple jsdoc 3 generator.  It pulls documentation tags based on a subset of [jsdoc 3](http://usejsdoc.org/) from your javascript files and generates [markdown](http://daringfireball.net/projects/markdown/) files.
 
-Relies on the [JSDoc3 parser](https://github.com/mrjoelkemp/jsdoc3-parser) to get the full AST including comments
+Relies on the [JSDoc3 parser](https://github.com/mrjoelkemp/jsdoc3-parser) to get the full AST including comments.
 
 # Resources
 * [jsdox](http://jsdox.org) Documentation
 * Github [repo](https://github.com/sutoiku/jsdox)
 * Issue [tracker](https://github.com/sutoiku/jsdox/issues)
-* Contribute by creating [pull requests](https://github.com/sutoiku/jsdox/pulls)!
+* Contribute by [reading the guidelines](https://github.com/sutoiku/jsdox/blob/master/Contributing.md) and creating [pull requests](https://github.com/sutoiku/jsdox/pulls)!
 * Run the test suite using `npm test`
 
 # Related projects


### PR DESCRIPTION
Adds some details on how to contribute to jsdox.
