### PR TITLE
template changes

### DIFF
--- a/templates/class.mustache
+++ b/templates/class.mustache
@@ -1,11 +1,10 @@
 {{#name}}
-{{name}}
-===
+## Class: {{name}}
 {{/name}}
 {{#description}}{{{description}}}{{/description}}
 
 {{#members}}
-**{{name}}** - {{{description}}}
+**{{name}}**: {{#typesString}}`{{typesString}}`{{/typesString}} {{#description}}, {{{description}}}{{/description}}
 {{/members}}
 {{#methods}}
 {{> function}}

--- a/templates/file.mustache
+++ b/templates/file.mustache
@@ -1,7 +1,6 @@
 {{#modules}}
 {{#name}}
-{{name}}
-===
+# {{name}}
 {{/name}}
 
 {{#description}}{{{description}}}{{/description}}
@@ -22,7 +21,14 @@
 {{/members}}
 {{/hasMembers}}
 
----
+{{#examples}}
+**Example:**
+```js
+{{{examples}}}
+```
+
+{{/examples}}
+* * *
 
 {{#functions}}
 {{> function}}
@@ -34,11 +40,13 @@
 {{/classes}}
 
 {{/modules}}
----
+* * *
 
 {{#copyright}}*{{copyright}}*{{/copyright}}
 
-{{#license}}**License:** {{license}} {{/license}}{{#author}}{{author}}{{/author}}
+{{#author}}**Author:** {{author}}{{/author}}
+
+{{#license}}**License:** {{license}} {{/license}}
 
 {{#overview}}**Overview:** {{{overview}}}{{/overview}}
 

--- a/templates/function.mustache
+++ b/templates/function.mustache
@@ -1,5 +1,5 @@
-{{#moduleName}}{{moduleName}}.{{/moduleName}}{{#className}}{{className}}.{{/className}}{{name}}({{#paramsString}}{{paramsString}}{{/paramsString}}) {{#version}}{{version}}{{/version}}
------------------------------
+### {{#moduleName}}{{moduleName}}.{{/moduleName}}{{#className}}{{className}}.{{/className}}{{name}}({{#paramsString}}{{paramsString}}{{/paramsString}}) {{#version}}{{version}}{{/version}}
+
 {{#description}}
 {{{description}}}
 
@@ -13,7 +13,7 @@ Deprecated: {{{deprecated}}}
 
 {{/hasParams}}
 {{#params}}
-**{{name}}**: {{#typesString}}{{typesString}}, {{/typesString}}{{#description}}{{{description}}}{{/description}}
+**{{name}}**: {{#typesString}}`{{typesString}}`{{/typesString}}{{#description}}, {{{description}}}{{/description}}
 
 {{/params}}
 {{#fires}}
@@ -21,5 +21,13 @@ Deprecated: {{{deprecated}}}
 
 {{/fires}}
 {{#returns}}
-**Returns**: {{#typesString}}{{typesString}}, {{/typesString}}{{#description}}{{{description}}}{{/description}}
+**Returns**: {{#typesString}}`{{typesString}}`{{/typesString}}{{#description}}, {{{description}}}{{/description}}
 {{/returns}}
+
+{{#examples}}
+**Example**:
+```js
+{{{examples}}}
+```
+
+{{/examples}}


### PR DESCRIPTION
- normalizing headers to pound format
- use alternate horizontal rules so you don't get them confused with headers
- adding types to members
- types display monospace
- classes prefixed with "Class:"
- `@example` tag support for `@module` and `@function`
- separate `@author` from `@license`
