### PR TITLE
Correctly check for @private tag (fixes #60)

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -204,5 +204,5 @@ function setPipedTypesString(node) {
 }
 
 function isInternal(tag){
-  return tag && ((tag.name && tag.name.lastIndexOf('_', 0) === 0) || tag.private);
+  return tag && ((tag.name && tag.name.lastIndexOf('_', 0) === 0) || tag.access === 'private');
 }


### PR DESCRIPTION
A shortened version of the AST looks like this:

``` json
{
  "comment": "... */",
  "description": "...",
  "params": [],
  "returns": [],
  "access": "private",
}
```

Even though my code uses `@private`, it still gets expanded to `access: "private"` in the AST.  This means that `tag.private` was always undefined, and `isInternal` was incorrectly returning false. This fixes that.
