### PR TITLE
*NOT READY* Refactor

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -68,5 +68,7 @@
   "requireDotNotation": true,
   "disallowYodaConditions": true,
   "disallowNewlineBeforeBlockStatements": true,
-  "validateLineBreaks": "LF"
+  "validateLineBreaks": "LF",
+  "requireSpaceAfterLineComment": true,
+  "safeContextKeyword": "self"
 }

--- a/lib/generateForDir.js
+++ b/lib/generateForDir.js
@@ -1,0 +1,83 @@
+var util = require('./util');
+var path = require('path');
+var fs = require('fs');
+var q = require('q');
+var dir = require('node-dir');
+var mkdirp = require('mkdirp');
+
+var generateForFile = require('./generateForFile');
+
+/**
+ * @param  {Object}   options
+ * @param  {String}   options.filename
+ * @param  {String}   options.destination
+ * @param  {String}   options.templateDir
+ * @param  {Function} options.fileCb
+ * @returns {Promise}
+ *
+ * @todo: Support options instead of separate params. Be sure to update grunt-jsdox
+ */
+module.exports = function(options) {
+  var deferred = q.defer();
+
+  var filename = options.filename;
+  var fileDir = path.dirname(filename);
+  var output = options.output;
+  var templateDir = options.templateDir;
+  var fileCb = options.fileCb;
+  var argv = options.argv;
+
+  var self = this;
+
+  // Aggregated index data about the directory
+  this.index = {
+    classes: [],
+    functions: []
+  };
+
+  var aggregateIndexData = function(file, data) {
+    var index;
+    if (argv.index) {
+      index = generateIndexData(data);
+      self.index.classes = self.index.classes.concat(index.classes);
+      self.index.functions = self.index.functions.concat(index.functions);
+    }
+  }
+
+  // If it's just a file and not a directory
+  if (filename.match(/\.js$/)) {
+    generateForFile({
+      directory: fileDir,
+      file: path.basename(filename),
+      argv: argv
+    })
+    .then(aggregateIndexData)
+    .then(deferred.resolve.bind(deferred));
+
+  } else {
+    dir.readFiles(directory,
+    {
+      match: /.js$/,
+      exclude: /^\./,
+    },
+    function (err, content, filename, next) {
+      next();
+    },
+    function(err, files) {
+      q.all(files.map(function(filename) {
+        mkdirp.sync(path.join(output, path.dirname(filename)));
+
+        return generateForFile({
+          directory: fileDir,
+          file: filename,
+          argv: argv,
+          templateDir: templateDir
+        }).then(aggregateIndexData);
+      }))
+      .then(deferred.resolve.bind(deferred));
+    });
+  }
+
+  return deferred.promise;
+};
+

--- a/lib/generateForFile.js
+++ b/lib/generateForFile.js
@@ -1,0 +1,85 @@
+var path = require('path');
+var jsdocParser = require('jsdoc3-parser');
+var fs = require('fs');
+var q = require('q');
+
+var util = require('./util');
+var analyze = require('./analyze');
+var generateMD = require('./generateMD');
+
+/**
+ * Generates the markdown output for a single JS file
+ *
+ * @param  {Object} options
+ * @param  {String} options.directory
+ * @param  {String} options.file
+ * @param  {Object} options.argv
+ * @param  {String} options.templateDir
+ * @return {Promise} Resolves with the file {String} and the analyzed ast {Object}
+ */
+module.exports = function(options) {
+  console.log(options)
+
+  var deferred = q.defer();
+  var filename = options.filename;
+  var fileDir = path.dirname(filename);
+  var fileBase = path.basename(filename);
+  var argv = options.argv;
+  var outputPath;
+  var outputDir;
+
+  // Lazy way to check if it's a directory without
+  // hitting the filesystem, in case the output dir doesn't exist yet
+  if (path.dirname(argv.output) === argv.output) {
+    // Markdown should be in the proper subdirectory of the output dir
+    if (argv.recursive) {
+      outputPath = path.join(path.join(argv.output, fileDir), fileBase);
+
+    // Just dump the markdown into the output folder
+    } else {
+      outputPath = path.join(argv.output, fileBase);
+    }
+
+  // We're storing the markdown in a separate file
+  } else {
+    outputPath = argv.output;
+  }
+
+  console.log('fullpath: ', outputPath)
+  outputPath = outputPath.replace(/\.js$/, '.md');
+
+  if (argv.debug) {
+    console.log('Generating', outputPath);
+  }
+
+  jsdocParser(filename, function(err, result) {
+    if (err) {
+      console.error('Error generating docs for file', filename, err);
+      deferred.reject(err);
+      return;
+    }
+
+    if (options.debug) {
+      console.log(file + ' AST: ', util.inspect(result));
+      console.log(file + ' Analyzed: ', util.inspect(analyze(result)));
+    }
+
+    var data = analyze(result, argv);
+    var output = generateMD(data, options.templateDir);
+
+    try {
+      if (output) {
+        fs.writeFileSync(outputPath, output);
+      }
+
+      deferred.resolve(filename, data);
+      return;
+
+    } catch (err) {
+      console.error('Error generating docs for file', filename, err);
+      deferred.reject(err);
+    }
+  });
+
+  return deferred.promise;
+};

--- a/lib/generateIndex.js
+++ b/lib/generateIndex.js
@@ -1,0 +1,29 @@
+/**
+ * Aggregates functions and classes for an index page
+ * @param  {Object} data - Analyzed ast
+ * @return {Object} Index data
+ */
+module.exports = function(data) {
+  var index = {
+    classes: [],
+    functions: []
+  };
+
+  data.functions.forEach(function(toAddFct) {
+    if (toAddFct.className === undefined) {
+      toAddFct.file = path.relative(destination, fullpath);
+      toAddFct.sourcePath = path.relative(destination, path.join(directory, path.basename(file)));
+      index.functions.push(toAddFct);
+    }
+  });
+
+  data.classes.forEach(function(toAddClass) {
+    if (toAddClass.className === undefined) {
+      toAddClass.file = path.relative(destination, fullpath);
+      toAddClass.sourcePath = path.relative(destination, path.join(directory, path.basename(file)));
+      index.classes.push(toAddClass);
+    }
+  });
+
+  return index;
+};

--- a/lib/generateMD.js
+++ b/lib/generateMD.js
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) 2012-2014 Sutoiku
- *
  */
 
 var Mustache = require('mustache');
@@ -9,7 +8,7 @@ var path = require('path');
 
 /**
  * Renders markdown from the given analyzed AST
- * @param  {Object} ast - output from analyze()
+ * @param  {Object} ast
  * @param  {String} templateDir - templates directory (optional)
  * @return {String} Markdown output
  */
@@ -24,38 +23,33 @@ module.exports = function(ast, templateDir, isIndex) {
     templateDir = templateDir.replace(/\\/g, '/');
   }
 
-  //if ast is an index file, we need to sort the contents and to use the right templates;
+  // If ast is an index file, we need to sort the contents and to use the right templates
   if (isIndex) {
     console.log('Now generating index');
+
     ast.classes.sort(function(a, b) {
-      if (a.name < b.name) {
-        return -1;
-      } else {
-        return 1;
-      }
+      return a.name < b.name ? -1 : 1;
     });
+
     ast.functions.sort(function(a, b) {
-      if (a.name < b.name) {
-        return -1;
-      } else {
-        return 1;
-      }
+      return a.name < b.name ? -1 : 1;
     });
 
     templates = {
       index: fs.readFileSync(templateDir + '/index.mustache', 'utf8'),
-      class: fs.readFileSync(templateDir + '/overview.mustache', 'utf8'),//do we need different overview templates for functions or classes here ?
+      class: fs.readFileSync(templateDir + '/overview.mustache', 'utf8'),
       function: fs.readFileSync(templateDir + '/overview.mustache', 'utf8')
     };
+
     return Mustache.render(templates.index, ast, templates);
-  }else {
 
-
+  } else {
     templates = {
       file: fs.readFileSync(templateDir + '/file.mustache', 'utf8'),
       class: fs.readFileSync(templateDir + '/class.mustache', 'utf8'),
       function: fs.readFileSync(templateDir + '/function.mustache', 'utf8')
     };
+
     return Mustache.render(templates.file, ast, templates);
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2012-2014 Sutoiku
+ */
+
+var fs = require('fs');
+var util = require('util');
+var path = require('path');
+
+/**
+ * Recursive readdirSync
+ * @param  {String} dir
+ * @param  {String[]} filelist
+ * @return {String[]}
+ */
+module.exports.readdirSyncRec = function(dir, filelist) {
+  var files = fs.readdirSync(dir);
+  var self = this;
+
+  filelist = filelist || [];
+  files.forEach(function(file) {
+    if (fs.statSync(path.join(dir, file)).isDirectory()) {
+      filelist = self.readdirSyncRec(path.join(dir, file), filelist);
+    } else {
+      filelist.push(path.join(dir, file));
+    }
+  });
+  return filelist;
+};
+
+/**
+ * Pretty print utility
+ *
+ * @param  {Object} ast [description]
+ * @return {String}
+ */
+module.exports.inspect = function(ast) {
+  return util.inspect(ast, false, 20);
+};
+
+/**
+ * Shallow copy
+ * @param  {Object} obj1
+ * @param  {Object} obj2
+ */
+module.exports.extend = function(obj1, obj2) {
+  Object.keys(obj2).forEach(function(prop) {
+    obj1[prop] = obj2[prop];
+  });
+};
+
+/**
+ * Whether or not the given path represents a directory name
+ * The directory name does not have to be of a directory on the filesystem
+ * @param  {String}  path
+ * @return {Boolean}
+ */
+module.exports.isDirectoryPath = function(path) {
+  return path.dirname(path) === path;
+};
+
+/**
+ * Whether or not the given resource is a directory on the filesystem
+ * @param  {String}  path
+ * @return {Boolean}
+ */
+module.exports.isDirectory = function(path) {
+  return fs.lstatSync(path).isDirectory();
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "jsdoc3-parser": "^1.0.0",
     "mustache": "^0.8.2",
     "optimist": "~0.3.4",
-    "q": "^1.0.1"
+    "q": "^1.0.1",
+    "node-dir": "^0.1.6",
+    "mkdirp": "^0.5.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/test/jsdox.js
+++ b/test/jsdox.js
@@ -28,7 +28,7 @@ describe('jsdox', function() {
 
   it('generates non-empty output markdown files from the fixtures/ and the fixtures/under files', function(done) {
     var cmd = bin + ' fixtures/ -o sample_output -r';
-    //in case an old index.md is here
+    // In case an old index.md is here
     try {
       fs.unlinkSync('sample_output/index.md');
     } catch(err) {}
@@ -64,7 +64,7 @@ describe('jsdox', function() {
             var content = fs.readFileSync('sample_output/fixtures/' + outputFile).toString();
             expect(content).not.to.be.empty();
             nbFilesA += 1;
-            //clean for future tests
+            // Clean for future tests
             fs.unlinkSync('sample_output/fixtures/' + outputFile);
           }
         }
@@ -103,7 +103,7 @@ describe('jsdox', function() {
       });
       expect(nbFiles).to.be(7);
       expect(hasIndex).to.be(true);
-      //clean index for other tests
+      // Clean index for other tests
       fs.unlinkSync('sample_output/index.md');
 
       done();


### PR DESCRIPTION
Just an early PR to get a bird's eye view of the work in progress and establish some transparency.

Main efforts in this PR:

* Simplify key parts of the codebase to increase maintainability
* Isolate functionality into modules
* Deprecate the use of the `-rr` option and have `-r` absorb respecting the directory structure if the input is a directory
 * If the input is a file, then the markdown will be dumped into the root of the output directory (the old behavior of `-r`)
* Support the output being a markdown file: `jsdox myFile.js -o myOutput.md`

Fixes #49
Fixes #56