### PR TITLE
fix undefined "argv" when using in programatic context

### DIFF
--- a/jsdox.js
+++ b/jsdox.js
@@ -41,7 +41,7 @@ var debug = false;
  *
  * @type {Object}
  */
-var argv;
+var argv = {};
 
 /**
  * Pretty print utility


### PR DESCRIPTION
Programmatic usage of `jsdox` is pretty broken; try to run it via Gulp as in the documentation example.

Anyway, this will put a band-aid on the problem, so `grunt-jsdox` will at least function.

`generateForDir()` is too tightly coupled to the CLI and should be refactored.
