### PR TITLE
fix the error that occures when a class have no methods

### DIFF
--- a/fixtures/test7.js
+++ b/fixtures/test7.js
@@ -1,0 +1,25 @@
+/**
+ * @overview Test classes without methods.
+ * @license MIT
+ * @author Gabor Sar
+ */
+
+/**
+ * Test class.
+ *
+ * @class Test
+ * @param {*} a First parameter.
+ * @param {*} b Second parameter.
+ */
+function Test(a, b) {
+
+    /**
+     * @member {*} a First member.
+     */
+    this.a = a;
+
+    /**
+     * @member {*} b Second member.
+     */
+    this.b = b;
+}

--- a/jsdox.js
+++ b/jsdox.js
@@ -160,7 +160,7 @@ function generateForDir(filename, destination, templateDir, cb, fileCb) {
           }
         }
         for (var j = 0; j < data.classes.length; j++) {
-          if (data.functions[j].className === undefined) {
+          if (data.functions[j] && data.functions[j].className === undefined) {
             var toAddClass = data.classes[j];
             toAddClass.file = path.relative(destination, fullpath);
             toAddClass.sourcePath = path.relative(destination, path.join(directory, path.basename(file)));

--- a/sample_output/test7.md
+++ b/sample_output/test7.md
@@ -1,0 +1,26 @@
+# Global
+
+
+
+
+
+* * *
+
+## Class: Test
+Test class.
+
+**a**: `*` , First member.
+**b**: `*` , Second member.
+
+
+* * *
+
+
+
+**Author:** Gabor Sar
+
+**License:** MIT 
+
+**Overview:** Test classes without methods.
+
+

--- a/test/jsdox.js
+++ b/test/jsdox.js
@@ -44,7 +44,7 @@ describe('jsdox', function() {
           nbFiles += 1;
         }
       });
-      expect(nbFiles).to.be(7);
+      expect(nbFiles).to.be(8);
 
       done();
     });
@@ -72,7 +72,7 @@ describe('jsdox', function() {
           }
         }
       });
-      expect(nbFilesA).to.be(5);
+      expect(nbFilesA).to.be(6);
 
       fs.readdirSync('sample_output/fixtures/under').forEach(function(outputFile) {
         if (!fs.statSync('sample_output/fixtures/under/' + outputFile).isDirectory()) {
@@ -117,7 +117,7 @@ describe('jsdox', function() {
         nbFiles += 1;
         hasIndex = hasIndex || (outputFile === 'index.md');
       });
-      expect(nbFiles).to.be(8);
+      expect(nbFiles).to.be(9);
       expect(hasIndex).to.be(true);
       //clean index for other tests
       fs.unlinkSync('sample_output/index.md');


### PR DESCRIPTION
Given the following exapmle file (`test.js):
```JavaScript
/**
 * Test class.
 *
 * @class Test
 * @param {*} a First parameter.
 * @param {*} b Second parameter.
 */
function Test(a, b) {

    /**
     * @member {*} a First member.
     */
    this.a = a;

    /**
     * @member {*} b Second member.
     */
    this.b = b;
}
```

`jsdox` fails with the following messages:
```
.../node_modules/jsdox/jsdox.js:164
          if (data.functions[j].className === undefined) {
                               ^
TypeError: Cannot read property 'className' of undefined
    at .../node_modules/jsdox/jsdox.js:164:32
    at jsdocParser._onComplete (.../node_modules/jsdox/node_modules/jsdoc3-parser/index.js:43:3)
    at ChildProcess.exithandler (child_process.js:646:7)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:756:16)
    at Socket.<anonymous> (child_process.js:969:11)
    at Socket.emit (events.js:95:17)
    at Pipe.close (net.js:465:12)
```

The new test file (`fixtures/test7.js`) tests this scenario, and the pull request fixes this issue.