### PR TITLE
Adds support for nested params.

### DIFF
--- a/fixtures/test8.js
+++ b/fixtures/test8.js
@@ -1,0 +1,15 @@
+/**
+ * @title Object params
+*/
+
+/**
+  This is a test function
+  with a object that has attributes
+  @param {String} file filename to parse
+  @param {Object} [options] Changes behavior
+  @param {Boolean} options.enableOption1 should option1 be enabled
+  @param {Boolean} options.enableOption2 should option2 be enabled
+*/
+function optionsFunction(file, options) {
+  return true;
+}

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -99,9 +99,15 @@ module.exports = function(ast, argv) {
 
         var fn = tag;
         fn.params       = tag.params || [];
+        fn.params.forEach(function (p) {
+          p.nested = (p.name.indexOf('.') > -1);
+        });
         fn.hasParams    = !!fn.params.length;
         // For the function signature
-        fn.paramsString = fn.params.map(function(p) {
+        fn.paramsString = fn.params.filter(function (p) {
+          // Filter out nested params
+          return !p.nested;
+        }).map(function(p) {
           return p.name;
         }).join(', ');
 

--- a/sample_output/test8.md
+++ b/sample_output/test8.md
@@ -1,0 +1,37 @@
+# Global
+
+
+
+
+
+* * *
+
+### optionsFunction(file, options) 
+
+This is a test function
+  with a object that has attributes
+
+**Parameters**
+
+**file**: `String`, filename to parse
+
+**options**: `Object`, Changes behavior
+
+ - **options.enableOption1**: `Boolean`, should option1 be enabled
+
+ - **options.enableOption2**: `Boolean`, should option2 be enabled
+
+
+
+
+* * *
+
+
+
+
+
+
+
+
+
+

--- a/templates/function.mustache
+++ b/templates/function.mustache
@@ -13,7 +13,7 @@ Deprecated: {{{deprecated}}}
 
 {{/hasParams}}
 {{#params}}
-**{{name}}**: {{#typesString}}`{{typesString}}`{{/typesString}}{{#description}}, {{{description}}}{{/description}}
+{{#nested}} - {{/nested}}**{{name}}**: {{#typesString}}`{{typesString}}`{{/typesString}}{{#description}}, {{{description}}}{{/description}}
 
 {{/params}}
 {{#fires}}

--- a/test/jsdox.js
+++ b/test/jsdox.js
@@ -46,7 +46,7 @@ describe('jsdox', function() {
           nbFiles += 1;
         }
       });
-      expect(nbFiles).to.be(8);
+      expect(nbFiles).to.be(9);
 
       done();
     });
@@ -76,7 +76,7 @@ describe('jsdox', function() {
           }
         }
       });
-      expect(nbFilesA).to.be(6);
+      expect(nbFilesA).to.be(7);
 
       fs.readdirSync('sample_output/fixtures/under').forEach(function(outputFile) {
         if (!fs.statSync('sample_output/fixtures/under/' + outputFile).isDirectory()) {
@@ -125,7 +125,7 @@ describe('jsdox', function() {
           hasIndex = hasIndex || (outputFile === 'index.md');
         }
       });
-      expect(nbFiles).to.be(9);
+      expect(nbFiles).to.be(10);
       expect(hasIndex).to.be(true);
       //clean index for other tests
       fs.unlinkSync('sample_output/index.md');


### PR DESCRIPTION
fixes utoiku/jsdox#88

I added the logic for that one. Then added test8.js to test these scenario, but I don't really know how these unit test are working. What do they mean with jsdox generates non-empty output markdown files.

Anyway my tests outputs as expected.